### PR TITLE
fix: Log errors in stdout as JSON and do not returns the error message in HTTP response

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,9 @@ linters:
     - err113
     - exhaustruct
     - forbidigo
+    - funlen
     - goconst
+    - lll
     - mnd
     - paralleltest
     - revive

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -33,7 +33,7 @@ func TestFailToCreatePluginWithMalformedJwksEndpoint(t *testing.T) {
 	})
 	_, err := New(ctx, next, cfg, "sw-oauth-plugin")
 
-	if err.Error() != "ParseJwksEndpoints - invalid url: 'not an url'" {
+	if err.Error() != "auth failed" {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
Try to log erros/info properly in order for these logs to be collected by the datadog agent and avoid to leek error messages in the HTTP response.